### PR TITLE
(1.7.10) Fix Aether buttons in modded GUI subclasses

### DIFF
--- a/src/main/java/com/gildedgames/the_aether/client/AetherClientEvents.java
+++ b/src/main/java/com/gildedgames/the_aether/client/AetherClientEvents.java
@@ -286,10 +286,11 @@ public class AetherClientEvents {
 	public void onGuiOpened(GuiScreenEvent.InitGuiEvent.Post event) {
 		if (event.gui instanceof GuiContainer) {
 			EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-			Class<?> clazz = event.gui.getClass();
 
 			int guiLeft = ObfuscationReflectionHelper.getPrivateValue(GuiContainer.class, (GuiContainer) event.gui, "guiLeft", "field_147003_i");
 			int guiTop = ObfuscationReflectionHelper.getPrivateValue(GuiContainer.class, (GuiContainer) event.gui, "guiTop", "field_147009_r");
+			int xSize = ObfuscationReflectionHelper.getPrivateValue(GuiContainer.class, (GuiContainer) event.gui, "xSize", "field_146999_f");
+			int ySize = ObfuscationReflectionHelper.getPrivateValue(GuiContainer.class, (GuiContainer) event.gui, "ySize", "field_147000_g");
 
 			if (player.capabilities.isCreativeMode) {
 				if (event.gui instanceof GuiContainerCreative) {
@@ -298,11 +299,14 @@ public class AetherClientEvents {
 						previousSelectedTabIndex = CreativeTabs.tabInventory.getTabIndex();
 					}
 				}
-			} else if (clazz == GuiInventory.class) {
-				event.buttonList.add(ACCESSORY_BUTTON.setPosition(guiLeft + 26, guiTop + 65));
+			} else if (event.gui instanceof GuiInventory) {
+				// We place the buttons where they would be if the inventory was its original size, for consistency with Baubles's button placement algorithm
+				int xSizeOriginal = 176;
+				int ySizeOriginal = 166;
+				event.buttonList.add(ACCESSORY_BUTTON.setPosition((xSize - xSizeOriginal) / 2 + guiLeft + 26, (ySize - ySizeOriginal) / 2 + guiTop + 65));
 			}
 
-			if (clazz == GuiAccessories.class)
+			if (event.gui instanceof GuiAccessories)
 			{
 				if (!shouldRemoveButton)
 				{
@@ -325,7 +329,7 @@ public class AetherClientEvents {
 			Minecraft.getMinecraft().displayGuiScreen(new AetherMainMenu());
 		}
 
-		if (event.gui.getClass() == GuiOptions.class)
+		if (event.gui instanceof GuiOptions)
 		{
 			if (Minecraft.getMinecraft().thePlayer != null)
 			{
@@ -336,7 +340,7 @@ public class AetherClientEvents {
 			}
 		}
 
-		if (event.gui.getClass() == ScreenChatOptions.class)
+		if (event.gui instanceof ScreenChatOptions)
 		{
 			if (Minecraft.getMinecraft().thePlayer != null)
 			{
@@ -371,7 +375,7 @@ public class AetherClientEvents {
 	@SubscribeEvent
 	public void onDrawGui(GuiScreenEvent.DrawScreenEvent.Pre event)
 	{
-		if (!AetherConfig.config.get("Misc", "Enables the Aether Menu", false).getBoolean() && event.gui.getClass() == AetherMainMenu.class)
+		if (!AetherConfig.config.get("Misc", "Enables the Aether Menu", false).getBoolean() && event.gui instanceof AetherMainMenu)
 		{
 			Minecraft.getMinecraft().displayGuiScreen(new GuiMainMenu());
 		}
@@ -379,18 +383,16 @@ public class AetherClientEvents {
 
 	@SubscribeEvent
 	public void onButtonPressed(GuiScreenEvent.ActionPerformedEvent.Pre event) {
-		Class<?> clazz = event.gui.getClass();
-
-		if ((clazz == GuiInventory.class || clazz == GuiContainerCreative.class) && event.button.id == 18067) {
+		if ((event.gui instanceof GuiInventory || event.gui instanceof GuiContainerCreative) && event.button.id == 18067) {
 			AetherNetwork.sendToServer(new PacketOpenContainer(AetherGuiHandler.accessories));
 		}
 
-		if (event.button.getClass() == GuiCustomizationScreenButton.class)
+		if (event.button instanceof GuiCustomizationScreenButton)
 		{
 			Minecraft.getMinecraft().displayGuiScreen(new GuiCustomizationScreen(event.gui));
 		}
 
-		if (event.button.getClass() == GuiCapeButton.class)
+		if (event.button instanceof GuiCapeButton)
 		{
 			PlayerAether player = PlayerAether.get(Minecraft.getMinecraft().thePlayer);
 

--- a/src/main/java/com/gildedgames/the_aether/client/gui/menu/AetherMainMenu.java
+++ b/src/main/java/com/gildedgames/the_aether/client/gui/menu/AetherMainMenu.java
@@ -491,7 +491,7 @@ public class AetherMainMenu extends GuiMainMenu
         {
             ((GuiButton) this.buttonList.get(j)).drawButton(this.mc, p_73863_1_, p_73863_2_);
 
-            if ((this.buttonList.get(j)).getClass() == AetherMainMenuButton.class)
+            if ((this.buttonList.get(j)) instanceof AetherMainMenuButton)
             {
                 if (((GuiButton) this.buttonList.get(j)).func_146115_a())
                 {


### PR DESCRIPTION
See https://github.com/gildedgames/aether-issues/issues/742.

In many places, the classes of GUI objects are directly compared with vanilla ones. These checks fail with subclasses of these classes introduced by mods, resulting in Aether's buttons not showing up in these GUIs. This happens in [InfiniteInvo](https://www.curseforge.com/minecraft/mc-mods/infiniteinvo) and [Satchels](https://www.curseforge.com/minecraft/mc-mods/satchels), which replace `GuiInventory` with their own subclass.
Even if these modded GUIs added the Aether button to their button lists manually, the buttons don't do anything when clicked because they fail the check in `onButtonPressed()`:
https://github.com/Gilded-Games/The-Aether-Archived/blob/63e9a73e80a990c5ae654c925d29b0062f4c22b5/src/main/java/com/gildedgames/the_aether/client/AetherClientEvents.java#L384

Since `instanceof` *is* used to compare GUI classes in a few places in an inconsistent manner, I am led to believe that this was made in error, and the intention was to use `instanceof` everywhere. This PR changes all GUI class comparisons to use `instanceof` unless this would cause an issue.

With this change, Aether's button now shows up in the modded inventory GUIs of both of the aforementioned mods, but in the wrong position.

![2021-08-31_06 16 46](https://user-images.githubusercontent.com/13667520/131452608-edff9a79-f31b-4ef3-b814-34b01236bd29.png)

To solve this, the button placement equation is changed to be consistent with how Baubles places its button. This should improve compatibility, since the Baubles button is what most mods are tested with, and can thus be considered the standard.

With this additional change, the Aether button now appears in the right position.

![2021-08-31_07 58 40](https://user-images.githubusercontent.com/13667520/131452589-dbe4f088-afb3-4087-ac3a-4b227c979f65.png)

---

I agree to the Contributor License Agreement found in [CONTRIBUTING.md](https://github.com/Gilded-Games/The-Aether-Archived/blob/1.7.10/CONTRIBUTING.md#contributor-license-agreement).