### PR TITLE
Moving confirmation for Aerogel creation event inside code block where Air is checked for.

### DIFF
--- a/src/main/java/com/gildedgames/the_aether/AetherEventHandler.java
+++ b/src/main/java/com/gildedgames/the_aether/AetherEventHandler.java
@@ -181,16 +181,15 @@ public class AetherEventHandler
 				{
 					worldObj.spawnParticle(EnumParticleTypes.SMOKE_LARGE, hitPos.getX() + 0.5, hitPos.getY() + 1, hitPos.getZ() + 0.5, 0, 0, 0);
 					event.getEntityPlayer().playSound(SoundEvents.ENTITY_GENERIC_EXTINGUISH_FIRE, 1.0F, 1.0F);
-					
+
 					worldObj.setBlockState(hitPos, BlocksAether.aerogel.getDefaultState());
 
 					if (!player.capabilities.isCreativeMode)
 					{
 						event.setFilledBucket(new ItemStack(Items.BUCKET));
 					}
+					event.setResult(Result.ALLOW);
 				}
-
-				event.setResult(Result.ALLOW);
 			}
 		}
 	}


### PR DESCRIPTION
Outside the block, this caused the event to attempt the aerogel creation and crash. When done by a machine, this is a crash loop and can brick the server until manually fixed.

Fixes https://github.com/Gilded-Games/The-Aether-Archived/issues/155