### PR TITLE
Fix Aether parachutes causing permanent crash 🪂

### DIFF
--- a/src/main/java/com/gildedgames/the_aether/entities/passive/mountable/EntityParachute.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/passive/mountable/EntityParachute.java
@@ -62,6 +62,12 @@ public class EntityParachute extends Entity implements IEntityAdditionalSpawnDat
             return;
         }
 
+        if (this.posY < 0) {
+            this.setDead();
+
+            return;
+        }
+
         if (this.ridingPlayer != null) {
             if (this.ridingPlayer.motionY < -0.25F) {
                 this.ridingPlayer.motionY = -0.25F;

--- a/src/main/java/com/gildedgames/the_aether/player/PlayerAether.java
+++ b/src/main/java/com/gildedgames/the_aether/player/PlayerAether.java
@@ -204,7 +204,7 @@ public class PlayerAether implements IPlayerAether {
 		this.getEntity().worldObj.theProfiler.startSection("portal");
 
 		if (this.getEntity().dimension == AetherConfig.getAetherDimensionID()) {
-			if (this.getEntity().posY < -2) {
+			if (this.getEntity().posY < -12) {
 				this.teleportPlayer(false);
 
 				if (this.riddenEntity != null)


### PR DESCRIPTION
After the player falls out of the Aether dimension with a parachute equipped, when re-entering the Aether the parachute is still there and due to being marked as being mounted with the player, causes a crash preventing the Aether from being entered again.

This commit causes parachutes to despawn when they get below y=0, and also lowers the height in which the player will 'fall out of' the Aether. (gives the parachute more time to despawn and also it's really annoying flying in creative falling at y<-2)

Code from Departure, I'm just the git gremlin

---

I agree to the Contributor License Agreement (CLA).