### PR TITLE
No longer allow generic modded plants from generating in Aether 🪚

### DIFF
--- a/src/main/java/com/gildedgames/the_aether/blocks/natural/BlockAetherGrass.java
+++ b/src/main/java/com/gildedgames/the_aether/blocks/natural/BlockAetherGrass.java
@@ -105,12 +105,13 @@ public class BlockAetherGrass extends Block implements IGrowable {
 		}
 	}
 
-	@Override
+	//This allows for other mods like Thaumcraft and Natura to generate their flora in the Aether as well, removing this fixes the problem
+	/*@Override
 	public boolean canSustainPlant(IBlockAccess world, int x, int y, int z, ForgeDirection direction, IPlantable plantable) {
 		EnumPlantType plantType = plantable.getPlantType(world, x, y + 1, z);
 
 		return plantType == EnumPlantType.Plains;
-	}
+	}*/
 
 	@Override
 	public boolean func_149851_a(World p_149851_1_, int p_149851_2_, int p_149851_3_, int p_149851_4_, boolean p_149851_5_) {


### PR DESCRIPTION
Mods like Natura, Thaumcraft, et al were generating their plants in the Aether, so commented out the toggle that allowed this.

Code from Departure, I'm just the git gremlin

---

I agree to the Contributor License Agreement (CLA).