### PR TITLE
Rename Aether's incubator TE to resolve mod conflict (DANGEROUS) 🥚❤️‍🔥☦️

### DIFF
--- a/src/main/java/com/gildedgames/the_aether/tileentity/AetherTileEntities.java
+++ b/src/main/java/com/gildedgames/the_aether/tileentity/AetherTileEntities.java
@@ -7,7 +7,7 @@ public class AetherTileEntities {
 	public static void initialization() {
 		GameRegistry.registerTileEntity(TileEntityEnchanter.class, "enchanter");
 		GameRegistry.registerTileEntity(TileEntityFreezer.class, "freezer");
-		GameRegistry.registerTileEntity(TileEntityIncubator.class, "incubator");
+		GameRegistry.registerTileEntity(TileEntityIncubator.class, "aether_incubator");
 		GameRegistry.registerTileEntity(TileEntityTreasureChest.class, "treasure_chest");
 		GameRegistry.registerTileEntity(TileEntityChestMimic.class, "chest_mimic");
 	}


### PR DESCRIPTION
This renames Aether's incubator tileentity to aether_incubator instead of just incubator, to resolve a mod conflict with a mod called "Essence of the G-ds"

___THIS WILL ERASE THE CONTENTS OF ALL INCUBATORS IN THE WORLD___

Personally I care more about existing save compat than weird mod compat, but meh your call

Code from Departure, I'm just the git gremlin

---

I agree to the Contributor License Agreement (CLA).