### PR TITLE
Boss Name Toggle + Starting Loot Toggle

### DIFF
--- a/src/main/java/com/gildedgames/the_aether/AetherConfig.java
+++ b/src/main/java/com/gildedgames/the_aether/AetherConfig.java
@@ -78,9 +78,7 @@ public class AetherConfig {
 		old_mobs = config.get("Misc", "Enable Legacy Visuals", false).getBoolean(false);
 
 		aether_start = config.get("Gameplay", "Spawns Player with Aether Portal Frame", false).getBoolean(false);
-
 		book_of_lore = config.get("Misc", "Gives the Player a Book of Lore upon entering the Aether for the first time", true).getBoolean(true);
-
 		book_of_lore = config.get("Misc", "Gives the Player a Golden Parachute upon entering the Aether for the first time", true).getBoolean(true);
 
 		max_life_shards = config.get("Gameplay", "Max Life Shards", 10).getInt(10);

--- a/src/main/java/com/gildedgames/the_aether/AetherConfig.java
+++ b/src/main/java/com/gildedgames/the_aether/AetherConfig.java
@@ -33,13 +33,15 @@ public class AetherConfig {
 
 	private static boolean aether_start;
 
+	private static boolean book_of_lore;
+
+	private static boolean golden_parachute;
+
 	private static boolean disable_eternal_day;
 
 	private static boolean toggle_music;
 
 	private static boolean boss_names;
-
-	private static boolean starting_equipment;
 
 	private static int phyg_spawnrate, flyingcow_spawnrate, sheepuff_spawnrate, aerbunny_spawnrate, moa_spawnrate, aerwhale_spawnrate;
 
@@ -77,7 +79,9 @@ public class AetherConfig {
 
 		aether_start = config.get("Gameplay", "Spawns Player with Aether Portal Frame", false).getBoolean(false);
 
-		starting_equipment = config.get("Misc", "Gives the Player a Book of Lore and Golden Parachute upon entering the Aether for the first time", true).getBoolean(true);
+		book_of_lore = config.get("Misc", "Gives the Player a Book of Lore upon entering the Aether for the first time", true).getBoolean(true);
+
+		book_of_lore = config.get("Misc", "Gives the Player a Golden Parachute upon entering the Aether for the first time", true).getBoolean(true);
 
 		max_life_shards = config.get("Gameplay", "Max Life Shards", 10).getInt(10);
 

--- a/src/main/java/com/gildedgames/the_aether/AetherConfig.java
+++ b/src/main/java/com/gildedgames/the_aether/AetherConfig.java
@@ -37,6 +37,10 @@ public class AetherConfig {
 
 	private static boolean toggle_music;
 
+	private static boolean boss_names;
+
+	private static boolean starting_equipment;
+
 	private static int phyg_spawnrate, flyingcow_spawnrate, sheepuff_spawnrate, aerbunny_spawnrate, moa_spawnrate, aerwhale_spawnrate;
 
 	private static int zephyr_spawnrate, cockatrice_spawnrate, swet_spawnrate, aechorplant_spawnrate, whirlwind_spawnrate;
@@ -73,6 +77,8 @@ public class AetherConfig {
 
 		aether_start = config.get("Gameplay", "Spawns Player with Aether Portal Frame", false).getBoolean(false);
 
+		starting_equipment = config.get("Misc", "Gives the Player a Book of Lore and Golden Parachute upon entering the Aether for the first time", true).getBoolean(true);
+
 		max_life_shards = config.get("Gameplay", "Max Life Shards", 10).getInt(10);
 
 		menu_enabled = config.get("Misc", "Enables the Aether Menu", false).getBoolean(false);
@@ -91,6 +97,8 @@ public class AetherConfig {
 		disable_eternal_day = config.get("Misc", "Disables eternal day making time cycle in the Aether without having to kill the Sun Spirit. This is mainly intended for use in modpacks.", false).getBoolean(false);
 
 		toggle_music = config.get("Misc", "Toggles the music in the Aether. Disable this if you use another mod that adds custom music (like MusicChoices)", true).getBoolean(true);
+
+		boss_names = config.get("Misc", "Enables randomly generated boss names", true).getBoolean(true);
 
 		//Spawnrates
 		phyg_spawnrate = config.get("Spawnrates", "Phyg Spawnrate. 1 is always, higher numbers decrease chances.", 1).getInt(1);

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/slider/EntitySlider.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/slider/EntitySlider.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.gildedgames.the_aether.Aether;
+import com.gildedgames.the_aether.AetherConfig;
 import com.gildedgames.the_aether.api.player.util.IAetherBoss;
 import com.gildedgames.the_aether.entities.util.AetherNameGen;
 import com.gildedgames.the_aether.entities.util.EntityAetherItem;
@@ -748,7 +749,12 @@ public class EntitySlider extends EntityFlying implements IAetherBoss {
 
     @Override
     public String getBossName() {
+       if (AetherConfig.config.get("Misc", "Enables randomly generated boss names", true).getBoolean()) {
         return this.dataWatcher.getWatchableObjectString(19) + ", " + StatCollector.translateToLocal("title.aether_legacy.slider.name");
+    }
+    else {
+        return this.StatCollector.translateToLocal("title.aether_legacy.slider.name");
+    }
     }
 
     @Override

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/slider/EntitySlider.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/slider/EntitySlider.java
@@ -753,7 +753,7 @@ public class EntitySlider extends EntityFlying implements IAetherBoss {
         return this.dataWatcher.getWatchableObjectString(19) + ", " + StatCollector.translateToLocal("title.aether_legacy.slider.name");
     }
     else {
-        return this.StatCollector.translateToLocal("title.aether_legacy.slider.name");
+        return StatCollector.translateToLocal("title.aether_legacy.slider.name");
     }
     }
 

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/sun_spirit/EntitySunSpirit.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/sun_spirit/EntitySunSpirit.java
@@ -665,7 +665,7 @@ public class EntitySunSpirit extends EntityFlying implements IMob, IAetherBoss, 
         return this.dataWatcher.getWatchableObjectString(19) + ", " + StatCollector.translateToLocal("title.aether_legacy.sun_spirit.name");
     }
     else {
-        return this.StatCollector.translateToLocal("title.aether_legacy.sun_spirit.name");
+        return StatCollector.translateToLocal("title.aether_legacy.sun_spirit.name");
     }
     }
 

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/sun_spirit/EntitySunSpirit.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/sun_spirit/EntitySunSpirit.java
@@ -661,7 +661,12 @@ public class EntitySunSpirit extends EntityFlying implements IMob, IAetherBoss, 
 
     @Override
     public String getBossName() {
-        return this.dataWatcher.getWatchableObjectString(20) + ", " + StatCollector.translateToLocal("title.aether_legacy.sun_spirit.name");
+    if (AetherConfig.config.get("Misc", "Enables randomly generated boss names", true).getBoolean()) {
+        return this.dataWatcher.getWatchableObjectString(19) + ", " + StatCollector.translateToLocal("title.aether_legacy.sun_spirit.name");
+    }
+    else {
+        return this.StatCollector.translateToLocal("title.aether_legacy.sun_spirit.name");
+    }
     }
 
     @Override

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
@@ -351,7 +351,13 @@ public class EntityValkyrieQueen extends EntityBossMob implements IAetherBoss {
         nbttagcompound.setInteger("DungeonZ", this.dungeonZ);
         nbttagcompound.setInteger("DungeonEntranceZ", this.dungeonEntranceZ);
         nbttagcompound.setTag("SafePos", newDoubleNBTList(new double[]{this.safeX, this.safeY, this.safeZ}));
-        nbttagcompound.setString("BossName", this.getName());
+        
+        if (AetherConfig.config.get("Misc", "Enables randomly generated boss names", true).getBoolean()) {
+            nbttagcompound.setString(this.getName());
+        }
+        else {
+            nbttagcompound.setString("BossName", this.getName());
+        }
     }
 
     @Override

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
@@ -598,7 +598,7 @@ public class EntityValkyrieQueen extends EntityBossMob implements IAetherBoss {
         return this.dataWatcher.getWatchableObjectString(19) + ", " + StatCollector.translateToLocal("title.aether_legacy.valkyrie_queen.name");
     }
     else {
-        return this.translateToLocal("title.aether_legacy.valkyrie_queen.name");
+        return StatCollector.translateToLocal("title.aether_legacy.valkyrie_queen.name");
     }
     }
 

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
@@ -351,13 +351,7 @@ public class EntityValkyrieQueen extends EntityBossMob implements IAetherBoss {
         nbttagcompound.setInteger("DungeonZ", this.dungeonZ);
         nbttagcompound.setInteger("DungeonEntranceZ", this.dungeonEntranceZ);
         nbttagcompound.setTag("SafePos", newDoubleNBTList(new double[]{this.safeX, this.safeY, this.safeZ}));
-        
-        if (AetherConfig.config.get("Misc", "Enables randomly generated boss names", true).getBoolean()) {
-            nbttagcompound.setString(this.getName());
-        }
-        else {
-            nbttagcompound.setString("BossName", this.getName());
-        }
+        nbttagcompound.setString("BossName", this.getName());
     }
 
     @Override
@@ -599,7 +593,12 @@ public class EntityValkyrieQueen extends EntityBossMob implements IAetherBoss {
 
     @Override
     public String getBossName() {
+    if (AetherConfig.config.get("Misc", "Enables randomly generated boss names", true).getBoolean()) {
         return this.dataWatcher.getWatchableObjectString(19) + ", " + StatCollector.translateToLocal("title.aether_legacy.valkyrie_queen.name");
+    }
+    else {
+        return this.StatCollector.translateToLocal("title.aether_legacy.valkyrie_queen.name");
+    }
     }
 
     public void setBossName(String name) {

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
@@ -2,9 +2,8 @@ package com.gildedgames.the_aether.entities.bosses.valkyrie_queen;
 
 import java.util.List;
 
-import com.gildedgames.the_aether.AetherConfig;
-
 import com.gildedgames.the_aether.Aether;
+import com.gildedgames.the_aether.AetherConfig;
 import com.gildedgames.the_aether.entities.util.EntityBossMob;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;

--- a/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/bosses/valkyrie_queen/EntityValkyrieQueen.java
@@ -2,6 +2,8 @@ package com.gildedgames.the_aether.entities.bosses.valkyrie_queen;
 
 import java.util.List;
 
+import com.gildedgames.the_aether.AetherConfig;
+
 import com.gildedgames.the_aether.Aether;
 import com.gildedgames.the_aether.entities.util.EntityBossMob;
 import net.minecraft.block.Block;
@@ -597,7 +599,7 @@ public class EntityValkyrieQueen extends EntityBossMob implements IAetherBoss {
         return this.dataWatcher.getWatchableObjectString(19) + ", " + StatCollector.translateToLocal("title.aether_legacy.valkyrie_queen.name");
     }
     else {
-        return this.StatCollector.translateToLocal("title.aether_legacy.valkyrie_queen.name");
+        return this.translateToLocal("title.aether_legacy.valkyrie_queen.name");
     }
     }
 

--- a/src/main/java/com/gildedgames/the_aether/player/PlayerAetherEvents.java
+++ b/src/main/java/com/gildedgames/the_aether/player/PlayerAetherEvents.java
@@ -167,14 +167,13 @@ public class PlayerAetherEvents {
 
 		if (!player.worldObj.isRemote && ((EntityPlayerMP) player).func_147099_x().canUnlockAchievement(achievement) && !((EntityPlayerMP) player).func_147099_x().hasAchievementUnlocked(achievement)) {
 			if (event.achievement == AchievementsAether.enter_aether) {
+				if (AetherConfig.config.get("Misc", "Gives the Player a Book of Lore upon entering the Aether for the first time", true).getBoolean()) {
 				if (!player.inventory.addItemStackToInventory(new ItemStack(ItemsAether.lore_book))) {
-					if (AetherConfig.config.get("Misc", "Gives the Player a Book of Lore upon entering the Aether for the first time", true).getBoolean()) {
 					player.worldObj.spawnEntityInWorld(new EntityItem(player.worldObj, player.posX, player.posY, player.posZ, new ItemStack(ItemsAether.lore_book)));
 					}
 				}
-
+				if (AetherConfig.config.get("Misc", "Gives the Player a Golden Parachute upon entering the Aether for the first time", true).getBoolean()) {
 				if (!player.inventory.addItemStackToInventory(new ItemStack(ItemsAether.golden_parachute))) {
-					if (AetherConfig.config.get("Misc", "Gives the Player a Golden Parachute upon entering the Aether for the first time", true).getBoolean()) {
 					player.worldObj.spawnEntityInWorld(new EntityItem(player.worldObj, player.posX, player.posY, player.posZ, new ItemStack(ItemsAether.golden_parachute)));
 					}
 				}

--- a/src/main/java/com/gildedgames/the_aether/player/PlayerAetherEvents.java
+++ b/src/main/java/com/gildedgames/the_aether/player/PlayerAetherEvents.java
@@ -168,11 +168,15 @@ public class PlayerAetherEvents {
 		if (!player.worldObj.isRemote && ((EntityPlayerMP) player).func_147099_x().canUnlockAchievement(achievement) && !((EntityPlayerMP) player).func_147099_x().hasAchievementUnlocked(achievement)) {
 			if (event.achievement == AchievementsAether.enter_aether) {
 				if (!player.inventory.addItemStackToInventory(new ItemStack(ItemsAether.lore_book))) {
+					if (AetherConfig.config.get("Misc", "Gives the Player a Book of Lore upon entering the Aether for the first time", true).getBoolean()) {
 					player.worldObj.spawnEntityInWorld(new EntityItem(player.worldObj, player.posX, player.posY, player.posZ, new ItemStack(ItemsAether.lore_book)));
+					}
 				}
 
 				if (!player.inventory.addItemStackToInventory(new ItemStack(ItemsAether.golden_parachute))) {
+					if (AetherConfig.config.get("Misc", "Gives the Player a Golden Parachute upon entering the Aether for the first time", true).getBoolean()) {
 					player.worldObj.spawnEntityInWorld(new EntityItem(player.worldObj, player.posX, player.posY, player.posZ, new ItemStack(ItemsAether.golden_parachute)));
+					}
 				}
 			}
 


### PR DESCRIPTION
-Adds a toggle for the randomly generated boss names so now you can fight the bosses without getting a face full of Aehgf'Tnafry'Avrugn'Cnbes'fur'g'u

-Adds toggles for receiving the Book of Lore and Golden Parachute upon entering the Aether for the first time (i made them separate config options in case someone needs to very specifically only have one enabled but not the other for whatever reasons)

---

I agree to the Contributor License Agreement (CLA).
