### PR TITLE
Added configs for several generation features + Moas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'com.wynprice.cursemaven'
 
-version = "1.12.2-v1.5.3.3"
+version = "1.12.2-v1.5.3.4"
 group = "com.gildedgames.the_aether"
 archivesBaseName = "aether"
 

--- a/src/main/java/com/gildedgames/the_aether/Aether.java
+++ b/src/main/java/com/gildedgames/the_aether/Aether.java
@@ -38,7 +38,7 @@ public class Aether
 
 	public static final String modid = "aether_legacy";
 
-	public static final String version = "1.5.3.2";
+	public static final String version = "1.5.3.4";
 
 	@Instance(Aether.modid)
 	public static Aether instance;

--- a/src/main/java/com/gildedgames/the_aether/AetherConfig.java
+++ b/src/main/java/com/gildedgames/the_aether/AetherConfig.java
@@ -41,6 +41,50 @@ public class AetherConfig
 		
 		@Config.Comment("Enables natural Pink Aercloud generation")
 		public boolean pink_aerclouds = false;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Pink Aerclouds will generate in about 1/X number of chunks.")
+		public int pink_aercloud_spawn_chance = 50;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Golden Aerclouds will generate in about 1/X number of chunks.")
+		public int golden_aercloud_spawn_chance = 50;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Blue Aerclouds will generate in about 1/X number of chunks.")
+		public int blue_aercloud_spawn_chance = 26;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Cold Aerclouds will generate in about 1/X number of chunks.")
+		public int cold_aercloud_spawn_chance = 14;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Crystal Tree Islands will generate in about 1/X number of chunks.")
+		public int crystal_island_spawn_chance = 37;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Spawn attempt 1 for Bronze Dungeons. Will succeed in about 1/X chunks.")
+		public int bronze_dungeon_primary_chance = 15;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Spawn attempt 2 for Bronze Dungeons. Will succeed in about 1/X chunks.")
+		public int bronze_dungeon_secondary_chance = 40;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Spawn attempt 1 for Silver Dungeons. Will succeed in about 1/X chunks.")
+		public int silver_dungeon_primary_chance = 110;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Spawn attempt 2 for Silver Dungeons. Will succeed in about 1/X chunks.")
+		public int silver_dungeon_secondary_chance = 150;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Spawn attempt 1 for Golden Dungeons. Will succeed in about 1/X chunks.")
+		public int golden_dungeon_primary_chance = 140;
+
+		@Config.RangeInt(min=1, max=1000000)
+		@Config.Comment("Spawn attempt 2 for Golden Dungeons. Will succeed in about 1/X chunks.")
+		public int golden_dungeon_secondary_chance = 170;
 	}
 	
 	public static final VisualOptions visual_options = new VisualOptions();
@@ -120,6 +164,43 @@ public class AetherConfig
 
 		@Config.Comment("Disables eternal day making time cycle in the Aether without having to kill the Sun Spirit. This is mainly intended for use in modpacks.")
 		public boolean disable_eternal_day = false;
+	}
+
+	public static final MoaStats moastats = new MoaStats();
+
+	public static class MoaStats {
+
+		@Config.RangeInt(min=0, max=10000)
+		@Config.Comment("The number of times that a blue Moa can jump.")
+		public int blue_moa_jumps = 3;
+
+		@Config.RangeDouble(min=0.1F, max=3F)
+		@Config.Comment("How fast a blue Moa can run.")
+		public float blue_moa_speed = 0.3F;
+
+		@Config.RangeInt(min=0, max=10000)
+		@Config.Comment("The number of times that an orange Moa can jump.")
+		public int orange_moa_jumps = 2;
+
+		@Config.RangeDouble(min=0.1F, max=3F)
+		@Config.Comment("How fast an orange Moa can run.")
+		public float orange_moa_speed = 0.6F;
+
+		@Config.RangeInt(min=0, max=10000)
+		@Config.Comment("The number of times that a white Moa can jump.")
+		public int white_moa_jumps = 4;
+
+		@Config.RangeDouble(min=0.1F, max=3F)
+		@Config.Comment("How fast a white Moa can run.")
+		public float white_moa_speed = 0.3F;
+
+		@Config.RangeInt(min=0, max=10000)
+		@Config.Comment("The number of times that a black Moa can jump.")
+		public int black_moa_jumps = 8;
+
+		@Config.RangeDouble(min=0.1F, max=3F)
+		@Config.Comment("How fast a black Moa can run.")
+		public float black_moa_speed = 0.3F;
 	}
 
 	public static final Spawnrates spawnrates = new Spawnrates();

--- a/src/main/java/com/gildedgames/the_aether/AetherConfig.java
+++ b/src/main/java/com/gildedgames/the_aether/AetherConfig.java
@@ -24,6 +24,11 @@ public class AetherConfig
 		@Config.RequiresMcRestart
 		@Config.Comment("Set the Dimension ID for the Aether.")
 		public int aether_dimension_id = 4;
+
+		@Config.RangeInt(min=2, max=256)
+		@Config.RequiresMcRestart
+		@Config.Comment("Set the Dimension ID when FALLING FROM the Aether.")
+		public int falling_dimension_id = 0;
 	}
 
 	public static final WorldGenOptions world_gen = new WorldGenOptions();

--- a/src/main/java/com/gildedgames/the_aether/entities/util/AetherMoaTypes.java
+++ b/src/main/java/com/gildedgames/the_aether/entities/util/AetherMoaTypes.java
@@ -1,5 +1,6 @@
 package com.gildedgames.the_aether.entities.util;
 
+import com.gildedgames.the_aether.AetherConfig;
 import com.gildedgames.the_aether.registry.creative_tabs.AetherCreativeTabs;
 import net.minecraftforge.registries.IForgeRegistry;
 
@@ -16,10 +17,10 @@ public class AetherMoaTypes
 
 	public static void initialization()
 	{
-		blue = register("blue", 0x7777FF, new MoaProperties(3, 0.3F));
-		orange = register("orange", -0xC3D78, new MoaProperties(2, 0.6F));
-		white = register("white", 0xFFFFFF, new MoaProperties(4, 0.3F));
-		black = register("black", 0x222222, new MoaProperties(8, 0.3F));
+		blue = register("blue", 0x7777FF, new MoaProperties(AetherConfig.moastats.blue_moa_jumps, AetherConfig.moastats.blue_moa_speed));
+		orange = register("orange", -0xC3D78, new MoaProperties(AetherConfig.moastats.orange_moa_jumps, AetherConfig.moastats.orange_moa_speed));
+		white = register("white", 0xFFFFFF, new MoaProperties(AetherConfig.moastats.white_moa_jumps, AetherConfig.moastats.white_moa_speed));
+		black = register("black", 0x222222, new MoaProperties(AetherConfig.moastats.black_moa_jumps, AetherConfig.moastats.black_moa_speed));
 	}
 
 	public static AetherMoaType register(String name, int hexColor, MoaProperties properties)

--- a/src/main/java/com/gildedgames/the_aether/player/PlayerAether.java
+++ b/src/main/java/com/gildedgames/the_aether/player/PlayerAether.java
@@ -510,12 +510,14 @@ public class PlayerAether implements IPlayerAether
 	/*
 	 * The teleporter which sends the player to the Aether/Overworld
 	 */
+
 	public void teleportPlayer(boolean shouldSpawnPortal)
 	{
 		if (this.thePlayer instanceof EntityPlayerMP)
 		{			
 			int previousDimension = this.thePlayer.dimension;
-			int transferDimension = previousDimension == AetherConfig.dimension.aether_dimension_id ? 0 : AetherConfig.dimension.aether_dimension_id;
+
+			int transferDimension = previousDimension == AetherConfig.dimension.aether_dimension_id ? AetherConfig.dimension.falling_dimension_id : AetherConfig.dimension.aether_dimension_id;
 
 			if (ForgeHooks.onTravelToDimension(this.thePlayer, transferDimension))
 			{

--- a/src/main/java/com/gildedgames/the_aether/world/biome/AetherBiomeDecorator.java
+++ b/src/main/java/com/gildedgames/the_aether/world/biome/AetherBiomeDecorator.java
@@ -132,12 +132,12 @@ public class AetherBiomeDecorator extends BiomeDecorator
 		{
 			if (AetherConfig.world_gen.pink_aerclouds || Loader.isModLoaded("lost_aether"))
 			{
-				this.generateClouds(EnumCloudType.Pink, 1, 50, this.nextInt(64) + 110);
+				this.generateClouds(EnumCloudType.Pink, 1, AetherConfig.world_gen.pink_aercloud_spawn_chance, this.nextInt(64) + 110);
 			}
 
-			this.generateClouds(EnumCloudType.Golden, 4, 50, this.nextInt(64) + 96);
-			this.generateClouds(EnumCloudType.Blue, 8, 26, this.nextInt(64) + 32);
-			this.generateClouds(EnumCloudType.Cold, 16, 14, this.nextInt(64) + 64);
+			this.generateClouds(EnumCloudType.Golden, 4, AetherConfig.world_gen.golden_aercloud_spawn_chance, this.nextInt(64) + 96);
+			this.generateClouds(EnumCloudType.Blue, 8, AetherConfig.world_gen.blue_aercloud_spawn_chance, this.nextInt(64) + 32);
+			this.generateClouds(EnumCloudType.Cold, 16, AetherConfig.world_gen.cold_aercloud_spawn_chance, this.nextInt(64) + 64);
 		}
 
 		if (TerrainGen.decorate(worldIn, random, pos, EventType.FLOWERS))
@@ -159,7 +159,7 @@ public class AetherBiomeDecorator extends BiomeDecorator
 				this.skyroot_tree.generate(this.world, this.rand, this.world.getHeight(this.chunkPos.add(this.nextInt(8) + 8, 0, this.nextInt(8) + 8)));
 			}
 
-			if (this.shouldSpawn(37))
+			if (this.shouldSpawn(AetherConfig.world_gen.crystal_island_spawn_chance))
 			{
 				this.crystal_island.generate(this.world, this.rand, this.chunkPos.add(8, this.nextInt(64) + 32, 8));
 			}

--- a/src/main/java/com/gildedgames/the_aether/world/dungeon/BronzeDungeon.java
+++ b/src/main/java/com/gildedgames/the_aether/world/dungeon/BronzeDungeon.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Random;
 
+import com.gildedgames.the_aether.AetherConfig;
 import com.gildedgames.the_aether.blocks.BlocksAether;
 import com.gildedgames.the_aether.blocks.dungeon.BlockDungeonBase;
 import com.gildedgames.the_aether.blocks.dungeon.BlockTreasureChest;
@@ -58,9 +59,9 @@ public class BronzeDungeon extends AetherDungeonVirtual
 
 		RandomTracker randomTracker = new RandomTracker();
 
-		if (randomTracker.testRandom(random,15) != 0)
+		if (randomTracker.testRandom(random, AetherConfig.world_gen.bronze_dungeon_primary_chance) != 0)
 		{
-			if (randomTracker.testRandom(random,40) != 0)
+			if (randomTracker.testRandom(random, AetherConfig.world_gen.bronze_dungeon_secondary_chance) != 0)
 			{
 				return false;
 			}

--- a/src/main/java/com/gildedgames/the_aether/world/gen/MapGenGoldenDungeon.java
+++ b/src/main/java/com/gildedgames/the_aether/world/gen/MapGenGoldenDungeon.java
@@ -3,6 +3,7 @@ package com.gildedgames.the_aether.world.gen;
 import java.util.Random;
 import java.util.Set;
 
+import com.gildedgames.the_aether.AetherConfig;
 import com.gildedgames.the_aether.world.gen.components.ComponentGoldenDungeon;
 import com.gildedgames.the_aether.world.gen.components.ComponentGoldenIsland;
 import com.gildedgames.the_aether.world.gen.components.ComponentGoldenIslandStub;
@@ -73,9 +74,9 @@ public class MapGenGoldenDungeon extends MapGenStructure
     {
         RandomTracker randomTracker = new RandomTracker();
 
-        if (randomTracker.testRandom(this.rand,140) != 0)
+        if (randomTracker.testRandom(this.rand, AetherConfig.world_gen.golden_dungeon_primary_chance) != 0)
         {
-            if (randomTracker.testRandom(this.rand,170) != 0)
+            if (randomTracker.testRandom(this.rand, AetherConfig.world_gen.golden_dungeon_secondary_chance) != 0)
             {
                 return false;
             }

--- a/src/main/java/com/gildedgames/the_aether/world/gen/MapGenSilverDungeon.java
+++ b/src/main/java/com/gildedgames/the_aether/world/gen/MapGenSilverDungeon.java
@@ -3,6 +3,7 @@ package com.gildedgames.the_aether.world.gen;
 import java.util.Random;
 import java.util.Set;
 
+import com.gildedgames.the_aether.AetherConfig;
 import com.gildedgames.the_aether.world.gen.components.ComponentSilverDungeon;
 import com.gildedgames.the_aether.world.util.RandomTracker;
 import net.minecraft.nbt.NBTTagCompound;
@@ -64,14 +65,14 @@ public class MapGenSilverDungeon extends MapGenStructure
         return null;
     }
 
-	@Override
+    @Override
     protected boolean canSpawnStructureAtCoords(int chunkX, int chunkZ)
     {
         RandomTracker randomTracker = new RandomTracker();
 
-        if (randomTracker.testRandom(this.rand, 110) != 0)
+        if (randomTracker.testRandom(this.rand, AetherConfig.world_gen.silver_dungeon_primary_chance) != 0)
         {
-            if (randomTracker.testRandom(this.rand, 150) != 0)
+            if (randomTracker.testRandom(this.rand, AetherConfig.world_gen.silver_dungeon_secondary_chance) != 0)
             {
                 return false;
             }

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "aether_legacy",
   "name": "The Aether",
   "description": "Gilded Games presents the original Aether mod! Up to date for modern Minecraft versions and fully compatible with multiplayer! The Aether is a dimension high in the sky comprised of floating islands! Ascend through a Glowstone portal and begin a new survival adventure packed with new ores, mythical creatures and perilous Dungeons!",
-  "version": "v1.5.3.2",
+  "version": "v1.5.3.4",
   "mcversion": "1.12.2",
   "url": "https://www.curseforge.com/minecraft/mc-mods/the-aether",
   "updateUrl": "",


### PR DESCRIPTION
Added several configs for tweaking the spawn rates of several generation features in the Aether, and for adjusting Moa stats.

---

-New config for adjusting spawn rates of the three dungeons, all aerclouds, and crystal tree islands

-New config for adjusting Moa run speed and jump count, per color

-Fixes #73 

---

I agree to the Contributor License Agreement (CLA).
